### PR TITLE
Improve date regex

### DIFF
--- a/get_data.py
+++ b/get_data.py
@@ -3,16 +3,9 @@ Lidl Receipt Data Updater
 =========================
 
 This module provides functions to handle both initial setup and incremental updates
-of Lidl receipt data with automatic date sor        wait = WebDriverWait(driver, 25)
-        wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "div.purchase-history_ticketsTable__D-i0e")))
-        
-        # Give page additional time to stabilize
-        time.sleep(3)
-        
-        ticket_elements = driver.find_elements(
-            By.CSS_SELECTOR, 
-            "div.purchase-history_ticketsTable__D-i0e a.ticket-row_row__3-1Iv"
-        )Usage:
+of Lidl receipt data with automatic date sorting.
+
+Usage:
     from lidl_updater import initial_setup, update_data
     
     # For first-time setup or complete refresh


### PR DESCRIPTION
Validate YYYYMMDD format instead of `20\d{6}`

- Prevents extraction of invalid 6-digit sequences after "20".
- New regex: `20\d{2}(?:0[1-9]|1[0-2])(?:[012]\d|3[01])`
  - years 2000–2099
  - months 01–12
  - days 01–31

see also: https://github.com/l2xu/shopping-analyzer/issues/11#issuecomment-3372928021