### PR TITLE
Progress display improvement

### DIFF
--- a/storage/receipt_repository.py
+++ b/storage/receipt_repository.py
@@ -6,7 +6,7 @@ from typing import Dict, Any
 from .file_manager import load_existing_receipts, save_receipts_to_json
 
 
-def add_receipt_to_json(receipt_data: Dict[str, Any]) -> None:
+def add_receipt_to_json(receipt_data: Dict[str, Any], verbose: bool = True) -> None:
     """Add or update a single receipt in the JSON file immediately."""
     existing_ids, existing_receipts = load_existing_receipts()
 
@@ -28,10 +28,11 @@ def add_receipt_to_json(receipt_data: Dict[str, Any]) -> None:
 
     save_receipts_to_json(existing_receipts)
 
-    action = "aktualisiert" if receipt_updated else "hinzugefügt"
-    print(
-        f"Kassenbon {action}: {receipt_data['purchase_date']} - {receipt_data['total_price']}"
-    )
+    if verbose:
+        action = "aktualisiert" if receipt_updated else "hinzugefügt"
+        print(
+            f"Kassenbon {action}: {receipt_data['purchase_date']} - {receipt_data['total_price']}"
+        )
 
 
 def sort_receipts_by_date() -> int:

--- a/workflows/collector.py
+++ b/workflows/collector.py
@@ -7,6 +7,7 @@ import requests
 from config import LidlConfig
 from api import get_tickets_page, get_receipt_details_and_html
 from storage import load_existing_receipts, add_receipt_to_json
+from .progress_display import ReceiptProgressDisplay, ProgressState
 
 
 def collect_all_receipt_ids(session: requests.Session) -> List[str]:
@@ -91,22 +92,65 @@ def process_all_tickets(session: requests.Session) -> Tuple[int, int, int]:
 
     print(f"Neue Kassenbons zu verarbeiten: {len(new_receipt_ids)}")
 
+    progress = ReceiptProgressDisplay()
+    total_new = len(new_receipt_ids)
+    total_items = 0
+    error_count = 0
+    current_receipt = "-"
+
+    progress.render(
+        ProgressState(
+            current=0,
+            total=total_new,
+            added=processed_count,
+            skipped=skipped_count,
+            errors=error_count,
+            items=total_items,
+            current_receipt=current_receipt,
+        )
+    )
+
     # Process each new receipt
     for i, receipt_id in enumerate(new_receipt_ids, 1):
-        print(f"Verarbeite Kassenbon {i}/{len(new_receipt_ids)}: {receipt_id}")
+        current_receipt = receipt_id
+        progress.render(
+            ProgressState(
+                current=i - 1,
+                total=total_new,
+                added=processed_count,
+                skipped=skipped_count,
+                errors=error_count,
+                items=total_items,
+                current_receipt=current_receipt,
+            )
+        )
 
         # Get receipt details and HTML
         receipt_data = get_receipt_details_and_html(session, receipt_id)
 
         if receipt_data and receipt_data["items"]:
-            add_receipt_to_json(receipt_data)
+            add_receipt_to_json(receipt_data, verbose=False)
             processed_count += 1
-            print(f"✓ Verarbeitet: {len(receipt_data['items'])} Artikel")
+            total_items += len(receipt_data["items"])
         else:
-            print("⚠ Fehler beim Verarbeiten")
             skipped_count += 1
+            error_count += 1
+
+        progress.render(
+            ProgressState(
+                current=i,
+                total=total_new,
+                added=processed_count,
+                skipped=skipped_count,
+                errors=error_count,
+                items=total_items,
+                current_receipt=current_receipt,
+            )
+        )
 
         # Add pause between requests to be respectful
         time.sleep(LidlConfig.REQUEST_DELAY)
+
+    progress.close()
 
     return processed_count, skipped_count, len(all_receipt_ids) // 10 + 1

--- a/workflows/progress_display.py
+++ b/workflows/progress_display.py
@@ -21,7 +21,7 @@ class ProgressState:
 class ReceiptProgressDisplay:
     """Render a fixed 3-line progress block in the terminal."""
 
-    def __init__(self, bar_width: int = 32) -> None:
+    def __init__(self, bar_width: int = 35) -> None:
         self.bar_width = bar_width
         self._initialized = False
 
@@ -30,7 +30,12 @@ class ReceiptProgressDisplay:
         total = max(state.total, 1)
         fraction = min(max(state.current / total, 0.0), 1.0)
         filled = int(self.bar_width * fraction)
-        bar = "#" * filled + "-" * (self.bar_width - filled)
+        cart_pos = min(filled, self.bar_width - 1)
+
+        bar_chars = ["="] * filled + ["-"] * (self.bar_width - filled)
+        if self.bar_width > 0:
+            bar_chars[cart_pos] = "🛒"
+        bar = "".join(bar_chars)
         percentage = fraction * 100
 
         line1 = f"[{bar}] {state.current}/{state.total} ({percentage:5.1f}%)"

--- a/workflows/progress_display.py
+++ b/workflows/progress_display.py
@@ -1,0 +1,55 @@
+"""Terminal progress display utilities for receipt processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ProgressState:
+    """Current progress metrics for rendering."""
+
+    current: int
+    total: int
+    added: int
+    skipped: int
+    errors: int
+    items: int
+    current_receipt: str = "-"
+
+
+class ReceiptProgressDisplay:
+    """Render a fixed 3-line progress block in the terminal."""
+
+    def __init__(self, bar_width: int = 32) -> None:
+        self.bar_width = bar_width
+        self._initialized = False
+
+    def render(self, state: ProgressState) -> None:
+        """Render progress in-place using ANSI cursor control."""
+        total = max(state.total, 1)
+        fraction = min(max(state.current / total, 0.0), 1.0)
+        filled = int(self.bar_width * fraction)
+        bar = "#" * filled + "-" * (self.bar_width - filled)
+        percentage = fraction * 100
+
+        line1 = f"[{bar}] {state.current}/{state.total} ({percentage:5.1f}%)"
+        line2 = (
+            f"Neu: {state.added} | Uebersprungen: {state.skipped} "
+            f"| Fehler: {state.errors} | Artikel: {state.items}"
+        )
+        line3 = f"Aktuell: {state.current_receipt}"
+
+        if self._initialized:
+            print("\033[3F", end="")
+        else:
+            self._initialized = True
+
+        print(f"\r\033[K{line1}")
+        print(f"\r\033[K{line2}")
+        print(f"\r\033[K{line3}", flush=True)
+
+    def close(self) -> None:
+        """Finalize rendering and move to the next line."""
+        if self._initialized:
+            print()

--- a/workflows/update_workflow.py
+++ b/workflows/update_workflow.py
@@ -7,6 +7,7 @@ from config import LidlConfig
 from auth import setup_and_test_session
 from api import get_tickets_page, get_receipt_details_and_html
 from storage import load_existing_receipts, add_receipt_to_json, sort_receipts_by_date
+from .progress_display import ReceiptProgressDisplay, ProgressState
 
 
 def update_data(
@@ -69,20 +70,64 @@ def update_data(
 
     # Process new receipts
     processed_count = 0
+    skipped_count = 0
+    error_count = 0
+    total_items = 0
+    progress = ReceiptProgressDisplay()
+    total_new = len(new_receipt_ids)
+    current_receipt = "-"
+
+    progress.render(
+        ProgressState(
+            current=0,
+            total=total_new,
+            added=processed_count,
+            skipped=skipped_count,
+            errors=error_count,
+            items=total_items,
+            current_receipt=current_receipt,
+        )
+    )
 
     for i, receipt_id in enumerate(new_receipt_ids, 1):
-        print(f"Verarbeite neuen Kassenbon {i}/{len(new_receipt_ids)}: {receipt_id}")
+        current_receipt = receipt_id
+        progress.render(
+            ProgressState(
+                current=i - 1,
+                total=total_new,
+                added=processed_count,
+                skipped=skipped_count,
+                errors=error_count,
+                items=total_items,
+                current_receipt=current_receipt,
+            )
+        )
 
         receipt_data = get_receipt_details_and_html(session, receipt_id)
 
         if receipt_data and receipt_data["items"]:
-            add_receipt_to_json(receipt_data)
+            add_receipt_to_json(receipt_data, verbose=False)
             processed_count += 1
-            print(f"✓ Hinzugefügt: {len(receipt_data['items'])} Artikel")
+            total_items += len(receipt_data["items"])
         else:
-            print("⚠ Fehler beim Verarbeiten")
+            skipped_count += 1
+            error_count += 1
+
+        progress.render(
+            ProgressState(
+                current=i,
+                total=total_new,
+                added=processed_count,
+                skipped=skipped_count,
+                errors=error_count,
+                items=total_items,
+                current_receipt=current_receipt,
+            )
+        )
 
         time.sleep(LidlConfig.REQUEST_DELAY)
+
+    progress.close()
 
     # Final sort if we added new receipts
     if processed_count > 0:
@@ -94,6 +139,8 @@ def update_data(
 
     print("\n=== UPDATE ABGESCHLOSSEN ===")
     print(f"Neue Kassenbons hinzugefügt: {processed_count}")
+    print(f"Fehler/Uebersprungen: {skipped_count}")
+    print(f"Verarbeitete Artikel: {total_items}")
     print(f"Gesamte Kassenbons in Datei: {total_receipts}")
 
     return True


### PR DESCRIPTION
I improved the progress display.
I have two variants:

**Standard loader**
![standard_loader](https://github.com/user-attachments/assets/f59e9b5c-ce1b-49a1-873e-022024d1b71a)

**Playful cart loader**
![cart_loader](https://github.com/user-attachments/assets/5f8d3e0d-cfed-41e3-bb55-5a6c6042eed9)

Currently the cart loader is active, to get the standard loader you have to revert one commit.
Let me know what you think!

Fixes #28 