### PR TITLE
Save richer data from the Lidl ticket API response and HTML

### DIFF
--- a/api/lidl_client.py
+++ b/api/lidl_client.py
@@ -96,10 +96,45 @@ def get_receipt_details_and_html(
         total_amount = ticket_data["totalAmount"]
 
         # Handle store info (could be nested or direct)
-        if isinstance(ticket_data.get("store"), dict):
-            store = ticket_data["store"].get("name", "Unknown")
+        raw_store = ticket_data.get("store", {})
+        if isinstance(raw_store, dict):
+            store = raw_store.get("name", "Unknown")
+            store_details = {
+                k: raw_store.get(k)
+                for k in ("id", "name", "address", "postalCode", "locality")
+                if raw_store.get(k) is not None
+            }
         else:
-            store = ticket_data.get("store", "Unknown")
+            store = raw_store or "Unknown"
+            store_details = {"name": store} if store else {}
+
+        # Log any fields in the API response that we don't currently use,
+        # so we can discover richer data the server may provide.
+        known_keys = {
+            "date", "totalAmount", "store", "htmlPrintedReceipt", "id", "isHtml",
+            # fields now captured
+            "codes", "storeNumber", "languageCode",
+            # presentational / low-value fields confirmed by inspection
+            "sequenceNumber", "workstation", "isDeleted",
+            "logoUrl", "showCopy", "collectingModel",
+            "returnTickets", "coupons",
+        }
+        unknown_keys = set(ticket_data.keys()) - known_keys
+        if unknown_keys:
+            print(f"  [API discovery] receipt {receipt_id} has extra fields: {sorted(unknown_keys)}")
+            for key in sorted(unknown_keys):
+                value = ticket_data[key]
+                # Truncate long values (e.g. nested HTML blobs)
+                repr_val = repr(value)
+                if len(repr_val) > 200:
+                    repr_val = repr_val[:200] + "…"
+                print(f"    {key}: {repr_val}")
+
+        # Also log top-level keys outside the ticket wrapper (if any)
+        if "ticket" in data:
+            outer_unknown = set(data.keys()) - {"ticket"}
+            if outer_unknown:
+                print(f"  [API discovery] outer response keys: {sorted(outer_unknown)}")
 
         # Get HTML content
         html_content = ticket_data.get("htmlPrintedReceipt", "")
@@ -112,6 +147,31 @@ def get_receipt_details_and_html(
         parsed_data = parse_receipt_html(
             html_content, receipt_id, receipt_date, total_amount, store
         )
+
+        if store_details:
+            parsed_data["store_details"] = store_details
+
+        if ticket_data.get("languageCode"):
+            parsed_data["language_code"] = ticket_data["languageCode"]
+
+        # Save receipt barcodes (e.g. return/loyalty codes printed on the receipt)
+        codes = ticket_data.get("codes")
+        if codes:
+            parsed_data["codes"] = [
+                {k: c[k] for k in ("code", "format", "codeType", "label", "position") if k in c}
+                for c in codes
+            ]
+
+        if ticket_data.get("storeNumber") is not None:
+            parsed_data["store_number"] = ticket_data["storeNumber"]
+
+        # Save coupon and return-ticket data from the outer response wrapper
+        # (these live outside the ticket object)
+        outer = data if "ticket" in data else {}
+        if outer.get("coupons"):
+            parsed_data["coupons"] = outer["coupons"]
+        if outer.get("returnTickets"):
+            parsed_data["return_tickets"] = outer["returnTickets"]
 
         return parsed_data
 

--- a/parsing/items_extractor.py
+++ b/parsing/items_extractor.py
@@ -86,6 +86,7 @@ def extract_receipt_items_from_html(soup: BeautifulSoup) -> List[Dict[str, Any]]
 
                 items.append(
                     {
+                        "art_id": main_span.get("data-art-id"),
                         "name": art_description,
                         "price": unit_price,
                         "quantity": art_quantity,

--- a/workflows/collector.py
+++ b/workflows/collector.py
@@ -37,6 +37,9 @@ def collect_all_receipt_ids(session: requests.Session) -> List[str]:
         if not tickets:
             break
 
+        # Log unknown fields on the first ticket of the first page for API discovery.
+        _logged_list_discovery = getattr(collect_all_receipt_ids, "_logged_list_discovery", False)
+
         # Extract receipt IDs from tickets (only those with HTML documents)
         for ticket in tickets:
             if isinstance(ticket, dict):
@@ -45,8 +48,23 @@ def collect_all_receipt_ids(session: requests.Session) -> List[str]:
                     receipt_id = ticket_data["id"]
                     has_html = ticket_data.get("isHtml", False)
                 else:
+                    ticket_data = ticket
                     receipt_id = ticket.get("id", "")
                     has_html = ticket.get("isHtml", False)
+
+                # Log unknown fields once to discover richer API data
+                if not _logged_list_discovery and isinstance(ticket_data, dict):
+                    known_list_keys = {"id", "isHtml", "date", "totalAmount", "store"}
+                    unknown = set(ticket_data.keys()) - known_list_keys
+                    if unknown:
+                        print(f"  [API discovery] ticket list item has extra fields: {sorted(unknown)}")
+                        for key in sorted(unknown):
+                            val = repr(ticket_data[key])
+                            if len(val) > 200:
+                                val = val[:200] + "…"
+                            print(f"    {key}: {val}")
+                    collect_all_receipt_ids._logged_list_discovery = True
+                    _logged_list_discovery = True
 
                 if receipt_id and has_html:
                     all_receipt_ids.append(receipt_id)


### PR DESCRIPTION
I'm marking this pull request as "draft" - it would be useful to discuss the usefulness of this pull request.

* art_id is a good thing to have - I think one cannot rely on the description of an item to uniquely identify it.  I will utilize it, with the art_id it's possible to match up purchases of the same item when visiting Lidl-shops operating in different languages.
* store_details - it's a lot of data, and at least for the Lidl I'm visiting at the moment the address is already included in the name of the shop.  Surely this information may be looked up through other means if one really needs it, it doesn't need to be repeated in the json blob for every shopping trip.
* language is nice to have, I think - it may also be deducted from the shop id and/or shop name.
* coupons / return_tickets - that's probably worth including.
* The "codes" is probably not useful?

Improvements that should be done:

* The commit message promises language, shop id and coupon information, but I can't find anything in the json produced - so there must be a bug someewhere.
* Probably, drop the store_details and codes?
* Add language code, that's also nice to have.

---

Commit message from Claude:

Additional fields now captured per receipt:
- store_details: full store address (name, address, postalCode, locality, id)
- codes: barcodes printed on the receipt (e.g. ReturnInfo CODE_128)
- language_code: receipt language
- store_number: store identifier when provided
- coupons / return_tickets: coupon and return-ticket data from the response

The existing store field (name string) is unchanged for compatibility.

Additional field per item:
- art_id: Lidl's internal article ID from the data-art-id HTML attribute,
  useful for consistent product identification across receipts

Also adds discovery logging: any fields returned by the API that are not
yet handled are printed to stdout, making future additions easy to spot.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
