### PR TITLE
Fix pfand fallback regex matching all item lines as deposit returns

### DIFF
--- a/parsing/receipt_parser.py
+++ b/parsing/receipt_parser.py
@@ -105,9 +105,12 @@ def parse_receipt_html(
                         pass
 
                 # If no direct Pfandrückgabe amount found, look for calculation lines
+                # with a *negative* integer quantity — pfand returns appear as e.g. "-3 x 0,25".
+                # Positive-quantity spans (regular items, kg weights like "0,248 x 3,55")
+                # must not be matched here.
                 if pfand_savings == 0:
                     pfand_calc_matches = re.findall(
-                        r"(-?\d+)\s*x\s*(-?\d+,\d+)", purchase_text
+                        r"(-\d+)\s*x\s*(\d+,\d+)", purchase_text
                     )
                     for qty_match, price_match in pfand_calc_matches:
                         try:

--- a/tests/test_receipt_parser.py
+++ b/tests/test_receipt_parser.py
@@ -1,0 +1,64 @@
+"""Tests for receipt_parser.py"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from parsing.receipt_parser import parse_receipt_html
+
+# Minimal Bulgarian-style receipt with two items sold by the piece.
+# The purchase_list contains "qty x unit_price" spans that must NOT be
+# treated as Pfandrückgabe / deposit-return lines.
+BG_RECEIPT_NO_PFAND = """
+<span class="purchase_list">
+  <span class="article" data-art-id="0496744" data-art-quantity="1" data-unit-price="12,77"
+        data-art-description="КОНСТРУКТОР ЦВЕТЕ">КОНСТРУКТОР ЦВЕТЕ</span>
+  <span class="article css_bold" data-art-id="0496744" data-art-quantity="1" data-unit-price="12,77"
+        data-art-description="КОНСТРУКТОР ЦВЕТЕ">12,77</span>
+  <span class="article" data-art-id="7202332" data-art-quantity="1" data-unit-price="3,06"
+        data-art-description="KINDER ШОК">KINDER ШОК</span>
+  <span class="article css_bold" data-art-id="7202332" data-art-quantity="1" data-unit-price="3,06"
+        data-art-description="KINDER ШОК">3,06</span>
+</span>
+"""
+
+# Same receipt but with a kg item whose span text is "0,248 x 3,55" —
+# this must not be misread as a deposit-return calculation either.
+BG_RECEIPT_KG_ITEM = """
+<span class="purchase_list">
+  <span class="article" data-art-id="0082440" data-art-quantity="0,2" data-unit-price="3,55"
+        data-art-description="ДОМАТИ РОМА">0,248 x 3,55</span>
+  <span class="article" data-art-id="0082440" data-art-quantity="0,2" data-unit-price="3,55"
+        data-art-description="ДОМАТИ РОМА">ДОМАТИ РОМА   0,88 B</span>
+</span>
+"""
+
+
+def test_no_pfand_savings_when_no_pfandrueckgabe_line():
+    """Items with 'qty x price' format must not inflate saved_pfand."""
+    result = parse_receipt_html(BG_RECEIPT_NO_PFAND, "r1", "2024.01.15", 0.0, "Lidl BG")
+    assert result.get("saved_pfand") is None, (
+        f"saved_pfand should be None but got {result.get('saved_pfand')!r} — "
+        "item calculation spans are being mistaken for Pfandrückgabe lines"
+    )
+
+
+def test_total_price_set_when_no_savings():
+    """total_price must equal total_price_no_saving when there are no savings or pfand."""
+    result = parse_receipt_html(BG_RECEIPT_NO_PFAND, "r1", "2024.01.15", 0.0, "Lidl BG")
+    assert result.get("total_price") is not None, (
+        "total_price is None — likely inflated pfand savings made final_paid go negative"
+    )
+    assert result.get("total_price") == result.get("total_price_no_saving"), (
+        f"total_price {result.get('total_price')!r} != "
+        f"total_price_no_saving {result.get('total_price_no_saving')!r}"
+    )
+
+
+def test_kg_item_span_not_treated_as_pfand():
+    """A 'qty x unit_price' kg-item span must not produce pfand savings."""
+    result = parse_receipt_html(BG_RECEIPT_KG_ITEM, "r2", "2024.01.15", 0.0, "Lidl BG")
+    assert result.get("saved_pfand") is None, (
+        f"saved_pfand should be None but got {result.get('saved_pfand')!r}"
+    )


### PR DESCRIPTION
As there is no bottle or boxes returns in Bulgaria (yet), I'm not able to test this changeset properly, leaving this as a draft PR untl someone else have the possibility to test (or until I get to visit Lidl in a country with bottle returns).  Th change solves a problem where the pfand line in the json file was wildly wrong, giving 0 EUR total amount for every shopping trip. Possibly due to differences between the German and Bulgarian shopping receipts.

---

The fallback pattern (-?\d+)\s*x\s*(-?\d+,\d+) matched any "qty x price"
span in the purchase list — including regular items and kg-weight lines like
"0,248 x 3,55". This inflated saved_pfand to roughly the full receipt total,
making final_paid go negative and leaving total_price as None (all zeros in
the dashboard).

Fixed by restricting the fallback to negative-integer quantities only
(-\d+)\s*x\s*(\d+,\d+), which is the actual format of bottle/can deposit
returns (e.g. "-3 x 0,25").

Adds tests/test_receipt_parser.py covering the bug and correct behaviour.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
